### PR TITLE
feat: Implement 6502 CPU core structure and register operations

### DIFF
--- a/src/cpu/mod.rs
+++ b/src/cpu/mod.rs
@@ -79,7 +79,7 @@ impl Cpu {
     /// - UNUSED flag must remain set
     ///
     /// Note: In a complete emulator, PC would be loaded from the reset vector
-    /// in memory. For now, it remains at its current value.
+    /// in memory. For now, we initialize it to 0x0000 to ensure a safe state.
     pub fn reset(&mut self) {
         self.a = 0;
         self.x = 0;
@@ -91,7 +91,9 @@ impl Cpu {
         self.set_flag(flags::UNUSED);
         self.set_flag(flags::INTERRUPT_DISABLE);
 
-        // PC will be loaded from reset vector ($FFFC-$FFFD) by the bus/memory system
+        // Initialize PC to a safe value
+        // TODO: Load the reset vector ($FFFC-$FFFD) from memory once the bus is wired
+        self.pc = 0x0000;
     }
 
     // ========================================
@@ -307,6 +309,7 @@ mod tests {
         assert_eq!(cpu.x, 0, "X register should be reset to 0");
         assert_eq!(cpu.y, 0, "Y register should be reset to 0");
         assert_eq!(cpu.sp, 0xFD, "Stack pointer should be reset to 0xFD");
+        assert_eq!(cpu.pc, 0x0000, "Program counter should be reset to 0x0000");
 
         // Verify status flags
         assert_eq!(


### PR DESCRIPTION
## Summary
Implements processor status flags and register operations for the 6502 CPU core.

## Changes
- Add processor status flag constants for all 8 flags
- Implement flag manipulation helper methods
- Enhance CPU initialization and reset logic
- Add 20 comprehensive unit tests

## Testing
- All 20 CPU unit tests passing
- No clippy warnings
- Code formatted with rustfmt

## Related Issues
Closes #2

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * CPU interface now exposes processor registers and status flags.
  * Comprehensive flag management API with direct accessors, mutators, and utilities.
  * Explicit CPU constructor and reset behavior that initialize registers and default flags.

* **Tests**
  * Added extensive tests covering initialization, reset behavior, flag manipulation, and status interactions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->