### PR TITLE
feat(ppu): implement VRAM and palette memory with mapper integration

### DIFF
--- a/src/cartridge/mappers/mod.rs
+++ b/src/cartridge/mappers/mod.rs
@@ -9,10 +9,12 @@ mod mapper2;
 mod mapper3;
 
 use super::{Cartridge, Mapper};
-use mapper0::Mapper0;
-use mapper1::Mapper1;
-use mapper2::Mapper2;
-use mapper3::Mapper3;
+
+// Re-export mapper implementations for use in tests and direct instantiation
+pub use mapper0::Mapper0;
+pub use mapper1::Mapper1;
+pub use mapper2::Mapper2;
+pub use mapper3::Mapper3;
 
 /// Error type for mapper creation
 #[derive(Debug)]


### PR DESCRIPTION
## Summary
Implements complete PPU VRAM and palette memory system by integrating mapper for pattern table access.

## Changes
- **PPU**: Add mapper reference for CHR-ROM/RAM access
- **PPU**: Implement pattern table read/write ($0000-$1FFF) via mapper
- **PPU**: Add `set_mapper()` method to connect cartridge
- **Mappers**: Export Mapper0-3 implementations for public use
- **Tests**: Add 8 comprehensive pattern table tests

## Memory Map (Complete)
```
$0000-$1FFF: Pattern tables (via mapper) ✅
$2000-$2FFF: Nametables (with mirroring) ✅ 
$3F00-$3F1F: Palette RAM (with mirroring) ✅
```

## Testing
- All 609 tests pass
- New tests cover CHR-ROM/RAM read/write scenarios
- CI checks pass (format, clippy, build, test)

## Dependencies
- Requires #27 (PPU registers) ✅

Closes #28

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Graphics subsystem now properly integrates with cartridge mappers for improved compatibility.

* **Refactor**
  * Mapper module structure improved for better internal accessibility and extensibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->