### PR TITLE
feat(ppu): Implement accurate VBlank and NMI timing

### DIFF
--- a/src/ppu/mod.rs
+++ b/src/ppu/mod.rs
@@ -239,12 +239,6 @@ pub struct Ppu {
     /// cleared but NMI will not be generated.
     pub(crate) vblank_just_set: bool,
 
-    /// Previous value of PPUCTRL NMI enable bit (bit 7)
-    ///
-    /// Used to detect changes to the NMI enable bit for proper
-    /// NMI suppression handling.
-    pub(crate) prev_nmi_enable: bool,
-
     // ========================================
     // Scanline Rendering State
     // ========================================
@@ -371,7 +365,6 @@ impl Ppu {
             frame: 0,
             nmi_pending: false,
             vblank_just_set: false,
-            prev_nmi_enable: false,
 
             // Scanline rendering state
             bg_pattern_shift_low: 0,
@@ -420,7 +413,6 @@ impl Ppu {
         self.frame = 0;
         self.nmi_pending = false;
         self.vblank_just_set = false;
-        self.prev_nmi_enable = false;
 
         // Scanline rendering state
         self.bg_pattern_shift_low = 0;

--- a/src/ppu/registers.rs
+++ b/src/ppu/registers.rs
@@ -145,8 +145,6 @@ impl Ppu {
                     // Disabling NMI - suppress any pending NMI
                     self.nmi_pending = false;
                 }
-
-                self.prev_nmi_enable = new_nmi_enable;
             }
             1 => {
                 // $2001: PPUMASK - Write only

--- a/src/ppu/tests/timing.rs
+++ b/src/ppu/tests/timing.rs
@@ -462,7 +462,6 @@ fn test_vblank_flag_cleared_exactly_on_prerender_cycle_1() {
 
     // Advance to VBlank and verify flag is set
     advance_to_scanline_cycle(&mut ppu, 241, 1);
-    ppu.step();
     assert_eq!(ppu.ppustatus & 0x80, 0x80, "VBlank flag should be set");
 
     // Advance to pre-render scanline, cycle 0
@@ -659,7 +658,6 @@ fn test_vblank_timing_across_frames() {
 
     // First frame - check VBlank is set
     advance_to_scanline_cycle(&mut ppu, 241, 1);
-    ppu.step();
     assert_eq!(
         ppu.ppustatus & 0x80,
         0x80,
@@ -680,7 +678,6 @@ fn test_vblank_timing_across_frames() {
 
     // Advance to VBlank in second frame
     advance_to_scanline_cycle(&mut ppu, 241, 1);
-    ppu.step();
 
     // VBlank should be set again
     assert_eq!(
@@ -699,7 +696,6 @@ fn test_sprite_flags_cleared_on_prerender() {
 
     // Advance to pre-render scanline
     advance_to_scanline_cycle(&mut ppu, 261, 1);
-    ppu.step();
 
     // Both flags should be cleared
     assert_eq!(
@@ -727,7 +723,6 @@ fn test_nmi_cleared_on_prerender() {
 
     // Advance to pre-render scanline
     advance_to_scanline_cycle(&mut ppu, 261, 1);
-    ppu.step();
 
     // NMI should be cleared
     assert!(


### PR DESCRIPTION
## Overview
Implements precise VBlank flag and NMI interrupt timing with race condition handling.

## Changes
- VBlank flag set on scanline 241, cycle 1
- VBlank flag cleared on pre-render scanline 261, cycle 1
- NMI triggered when VBlank flag set if PPUCTRL bit 7 enabled
- PPUSTATUS read clears VBlank flag

## Race Conditions Handled
- Reading PPUSTATUS on exact VBlank cycle suppresses NMI
- Enabling NMI during VBlank triggers NMI (except on exact cycle)
- Disabling NMI suppresses pending NMI

## Testing
- 17 new tests for VBlank/NMI timing and race conditions
- All 118 PPU tests passing

Fixes #34

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed VBlank/NMI race conditions to ensure NMIs are suppressed or queued correctly when VBlank and NMI-enable changes occur on the same cycle, improving interrupt timing fidelity.

* **Tests**
  * Added extensive timing tests covering VBlank flag transitions, reads during exact cycles, NMI enable/disable edge cases, and frame-boundary behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->