### PR TITLE
feat: implement APU pulse channels (Pulse 1 & 2)

### DIFF
--- a/src/apu/mod.rs
+++ b/src/apu/mod.rs
@@ -206,7 +206,8 @@ impl Sweep {
     fn clock(&mut self, current_period: u16) -> Option<u16> {
         let mut update_period = None;
 
-        if self.divider == 0 && self.enabled && !self.is_muting(current_period) {
+        // Only update period if shift > 0; muting still applies even when shift == 0
+        if self.divider == 0 && self.enabled && self.shift > 0 && !self.is_muting(current_period) {
             update_period = Some(self.calculate_target_period(current_period));
         }
 


### PR DESCRIPTION
## Summary
Implements full pulse wave channel support for the NES APU, resolving issue #39.

## Changes
- **PulseChannel struct**: Complete state machine for pulse wave generation
- **Duty cycle control**: All 4 patterns (12.5%, 25%, 50%, 75%)
- **Envelope generator**: Constant volume and decay modes
- **Sweep unit**: Period modulation with one's complement (Pulse 1) vs two's complement (Pulse 2)
- **Length counter**: Automatic note duration control with halt flag
- **Timer**: Frequency control with 11-bit precision
- **Sample generation**: Proper waveform synthesis with all components

## Key Features
- Pulse 1 and Pulse 2 differ in sweep negate calculation (one's vs two's complement)
- Integrated with $4015 status register for enable/disable
- Full register parsing for $4000-$4007
- Proper status reporting via $4015 reads

## Testing
- Added 13 comprehensive tests covering all functionality
- All 33 APU tests passing (755 total tests passing)
- Full CI pipeline passes

## Notes
- Triangle, Noise, and DMC channels remain as stubs for future implementation
- Audio output methods provided (`pulse1_output()`, `pulse2_output()`, `output()`)
- Frame sequencer methods (`clock_quarter_frame()`, `clock_half_frame()`) ready for integration

Closes #39

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Reworked audio subsystem to use modular pulse channels with per-channel timing and output handling.
  * Added detailed channel mechanics: envelopes, sweeps, length counters, timers, duty patterns, and refined status/muting semantics.
  * Introduced lifecycle methods for advancing channel timing and producing mixed/channel outputs.

* **Tests**
  * Substantially expanded test suite covering initialization, envelopes, length counters, sweeps, duty behaviors, muting, and multi-channel interactions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->